### PR TITLE
#1891 :sparkles: Add object filter for EnkelvoudigInformatieObject resource

### DIFF
--- a/.github/workflows/lint-oas.yml
+++ b/.github/workflows/lint-oas.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           node-version: '12'
       - name: Install spectral
-        run: npm install -g @stoplight/spectral
+        run: npm install -g @stoplight/spectral@5.9.2
       - name: Run OAS linter
         run: spectral lint ./src/openapi.yaml

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -158,6 +158,13 @@ paths:
         required: false
         schema:
           type: string
+      - name: object
+        in: query
+        description: De URL van het gerelateerde object (zoals vastgelegd in de OBJECTINFORMATIEOBJECT
+          resource). Meerdere waardes kunnen met komma's gescheiden worden.
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -158,6 +158,13 @@
                         "type": "string"
                     },
                     {
+                        "name": "object",
+                        "in": "query",
+                        "description": "De URL van het gerelateerde object (zoals vastgelegd in de OBJECTINFORMATIEOBJECT resource). Meerdere waardes kunnen met komma's gescheiden worden.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "page",
                         "in": "query",
                         "description": "Een pagina binnen de gepagineerde set resultaten.",


### PR DESCRIPTION
Issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1891 (the Documenten API part)

Changes:
* Add an `object` filter on `EnkelvoudigInformatieObject` resource, to allow filtering on related objecten (zaken/besluiten)
* Pin `spectral` dependency in CI to `5.9.2`