### PR TITLE
remove double prefix in redoc

### DIFF
--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -16,7 +16,6 @@ SPECTACULAR_SETTINGS.update(
     {
         "SERVERS": [{"url": "https://documenten-api.test.vng.cloud/api/v1"}],
         "COMPONENT_SPLIT_REQUEST": True,
-        # todo remove this line below when deploying to production
         "SORT_OPERATION_PARAMETERS": False,
     }
 )

--- a/src/drc/tests/test_lock_eio.py
+++ b/src/drc/tests/test_lock_eio.py
@@ -165,7 +165,6 @@ class EioUnlockAPITests(JWTAuthMixin, APITestCase):
         )
 
         response = self.client.post(url, {"lock": lock})
-
         self.assertEqual(
             response.status_code, status.HTTP_204_NO_CONTENT, response.data
         )


### PR DESCRIPTION
example:

https://documenten-api.test.vng.cloud/api/v1/api/v1/objectinformatieobjecten
to
https://documenten-api.test.vng.cloud/api/v1/objectinformatieobjecten